### PR TITLE
messages.ja.xmlの修正 (fixes #858)

### DIFF
--- a/i18n/messages.ja.xml
+++ b/i18n/messages.ja.xml
@@ -103,7 +103,7 @@
         <target>写真5</target>
       </trans-unit>
       <trans-unit id="">
-        <source>There are no albums</source>
+        <source>There are no albums.</source>
         <target>アルバムがありません</target>
       </trans-unit>
       <trans-unit id="">


### PR DESCRIPTION
Bug #858: アルバム未登録時のエラーメッセージが翻訳されていない
http://redmine.openpne.jp/issues/858

に対する修正です。
