### PR TITLE
アルバム編集画面で、表紙が設定されていない場合に壊れた画像が表示されている(refs #2003) の修正取り込みをお願いします

### DIFF
--- a/apps/pc_frontend/modules/album/templates/_formEditImage.php
+++ b/apps/pc_frontend/modules/album/templates/_formEditImage.php
@@ -1,3 +1,12 @@
-<a href="<?php echo sf_image_path($image->getCoverImage()) ?>" target="_blank"><?php echo image_tag_sf_image($image->getCoverImage(), array('size' => '120x120')) ?></a><br />
+<?php
+$imageTag = image_tag_sf_image($image->getCoverImage(), array('size' => '120x120'));
+if ($image->getFileId()): ?>
+<a href="<?php echo sf_image_path($image->getCoverImage()) ?>" target="_blank"><?php echo $imageTag ?></a><br />
 %input%<br />
 %delete% %delete_label%
+<?php
+else:
+  echo $imageTag; ?><br />
+%input%<br />
+<?php
+endif;

--- a/apps/pc_frontend/modules/album/templates/_formEditImage.php
+++ b/apps/pc_frontend/modules/album/templates/_formEditImage.php
@@ -1,12 +1,9 @@
-<?php
-$imageTag = image_tag_sf_image($image->getCoverImage(), array('size' => '120x120'));
-if ($image->getFileId()): ?>
+<?php $imageTag = image_tag_sf_image($image->getCoverImage(), array('size' => '120x120')); ?>
+<?php if ($image->getFileId()): ?>
 <a href="<?php echo sf_image_path($image->getCoverImage()) ?>" target="_blank"><?php echo $imageTag ?></a><br />
 %input%<br />
 %delete% %delete_label%
-<?php
-else:
-  echo $imageTag; ?><br />
+<?php else: ?>
+<?php echo $imageTag; ?><br />
 %input%<br />
-<?php
-endif;
+<?php endif; ?>

--- a/lib/form/doctrine/PluginAlbumForm.class.php
+++ b/lib/form/doctrine/PluginAlbumForm.class.php
@@ -39,12 +39,15 @@ abstract class PluginAlbumForm extends BaseAlbumForm
         'edit_mode'    => !$this->isNew(),
       );
 
-    if (!$this->isNew() && $this->getObject()->getFileId())
+    if (!$this->isNew())
     {
       sfContext::getInstance()->getConfiguration()->loadHelpers('Partial');
       $options['template'] = get_partial('album/formEditImage', array('image' => $this->getObject()));
-      $options['with_delete'] = true;
-      $this->setValidator('file_id_delete', new sfValidatorBoolean(array('required' => false)));
+      if ($this->getObject()->getFileId())
+      {
+        $options['with_delete'] = true;
+        $this->setValidator('file_id_delete', new sfValidatorBoolean(array('required' => false)));
+      }
     }
 
     $this->setWidget('file_id', new sfWidgetFormInputFileEditable($options, array('size' => 40)));


### PR DESCRIPTION
Bug（バグ） #2003: アルバム編集画面で、表紙が設定されていない場合に壊れた画像が表示されている
http://redmine.openpne.jp/issues/2003
の修正をおこないましたので、取り込みをお願いいたします。
