### PR TITLE
notnull 制約のある album_image.filesize に値がセットされない問題の修正 (#2236)

### DIFF
--- a/lib/model/doctrine/PluginAlbumImage.class.php
+++ b/lib/model/doctrine/PluginAlbumImage.class.php
@@ -25,6 +25,11 @@ abstract class PluginAlbumImage extends BaseAlbumImage
   {
     // album_image.member_id is must be same member
     $this->setMember($this->getAlbum()->getMember());
+
+    if (null === $this->filesize && null !== $this->file_id)
+    {
+      $this->filesize = strlen($this->File->FileBin->bin);
+    }
   }
 
   protected function setFileNamePrefix()


### PR DESCRIPTION
Bug（バグ） #2236: AlbumPhotoForm での画像アップロード時に album_image のレコードの filesize カラムに値がセットされていない
http://redmine.openpne.jp/issues/2236

に対する修正です。
