### PR TITLE
(refs #4202) Corrected so that newlines of explanatory text are defined.

### DIFF
--- a/apps/pc_frontend/modules/album/templates/showSuccess.php
+++ b/apps/pc_frontend/modules/album/templates/showSuccess.php
@@ -27,7 +27,7 @@
 </tr>
 <tr>
 <th><?php echo __('Description') ?></th>
-<td colspan="2"><?php echo $album->getBody() ?></td>
+<td colspan="2"><?php echo nl2br($album->getBody()) ?></td>
 </tr>
 <tr>
 <th><?php echo __('Public flag') ?></th>


### PR DESCRIPTION
http://redmine.openpne.jp/issues/4202